### PR TITLE
Fixes PHEE-310, PHEE 311 : Integration-test working with connector-common-1.5.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,6 +23,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter'
     testImplementation "com.github.tomakehurst:wiremock-jre8:2.35.0"
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    implementation 'org.mifos:ph-ee-connector-common:1.5.0-SNAPSHOT'
     testImplementation "com.google.truth:truth:1.1.3"
     testImplementation 'com.google.code.gson:gson:2.9.0'
     testImplementation('io.rest-assured:rest-assured:5.1.1') {
@@ -40,6 +41,12 @@ dependencies {
 
 tasks.named('test') {
     useJUnitPlatform()
+}
+
+configurations {
+    cucumberRuntime {
+        extendsFrom testImplementation
+    }
 }
 
 test {

--- a/build.gradle
+++ b/build.gradle
@@ -23,7 +23,6 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter'
     testImplementation "com.github.tomakehurst:wiremock-jre8:2.35.0"
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
-    implementation 'org.mifos:ph-ee-connector-common:1.5.0-SNAPSHOT'
     testImplementation "com.google.truth:truth:1.1.3"
     testImplementation 'com.google.code.gson:gson:2.9.0'
     testImplementation('io.rest-assured:rest-assured:5.1.1') {

--- a/build.gradle
+++ b/build.gradle
@@ -43,12 +43,6 @@ tasks.named('test') {
     useJUnitPlatform()
 }
 
-configurations {
-    cucumberRuntime {
-        extendsFrom testImplementation
-    }
-}
-
 test {
     systemProperty "cucumber.filter.tags", System.getProperty("cucumber.filter.tags")
 }

--- a/build.gradle
+++ b/build.gradle
@@ -22,9 +22,8 @@ repositories {
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter'
     testImplementation "com.github.tomakehurst:wiremock-jre8:2.35.0"
-    implementation 'org.mifos:ph-ee-connector-common:1.5.1-SNAPSHOT'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
-    implementation 'org.mifos:ph-ee-connector-common:1.5.1-SNAPSHOT'
+    implementation 'org.mifos:ph-ee-connector-common:1.5.0-SNAPSHOT'
     testImplementation "com.google.truth:truth:1.1.3"
     testImplementation 'com.google.code.gson:gson:2.9.0'
     testImplementation('io.rest-assured:rest-assured:5.1.1') {
@@ -36,6 +35,8 @@ dependencies {
     implementation 'io.cucumber:cucumber-java:7.8.1'
     implementation 'io.cucumber:cucumber-spring:7.8.1'
     testImplementation 'io.cucumber:cucumber-junit:7.8.1'
+
+    testRuntimeOnly("org.junit.vintage:junit-vintage-engine")
 }
 
 tasks.named('test') {
@@ -48,20 +49,6 @@ configurations {
     }
 }
 
-task cucumberCli() {
-    dependsOn assemble, testClasses
-    doLast {
-        javaexec {
-            main = "io.cucumber.core.cli.Main"
-            classpath = configurations.cucumberRuntime + sourceSets.main.output + sourceSets.test.output
-            args = [
-                    '--plugin', 'html:cucumber-report',
-                    '--plugin', 'json:cucumber.json',
-                    '--plugin', 'pretty',
-                    '--plugin', 'html:build/cucumber-report.html',
-                    '--plugin', 'json:build/cucumber-report.json',
-                    '--glue', 'org.mifos.integrationtest.cucumber',
-                    'src/test/java/resources']
-        }
-    }
+test {
+    systemProperty "cucumber.filter.tags", System.getProperty("cucumber.filter.tags")
 }

--- a/src/test/java/org/mifos/integrationtest/TestRunner.java
+++ b/src/test/java/org/mifos/integrationtest/TestRunner.java
@@ -1,0 +1,20 @@
+package org.mifos.integrationtest;
+
+import io.cucumber.junit.Cucumber;
+import io.cucumber.junit.CucumberOptions;
+import org.junit.runner.RunWith;
+
+@RunWith(Cucumber.class)
+@CucumberOptions(
+        features = {"src/test/java/resources"},
+        glue = {"org.mifos.integrationtest.cucumber"},
+        plugin = {
+            "html:cucumber-report",
+            "json:cucumber.json",
+            "pretty",
+            "html:build/cucumber-report.html",
+            "json:build/cucumber-report.json"
+        }
+)
+public class TestRunner {
+}

--- a/src/test/java/org/mifos/integrationtest/cucumber/CucumberContext.java
+++ b/src/test/java/org/mifos/integrationtest/cucumber/CucumberContext.java
@@ -1,13 +1,18 @@
 package org.mifos.integrationtest.cucumber;
 
+import io.cucumber.junit.Cucumber;
 import io.cucumber.junit.CucumberOptions;
 import io.cucumber.spring.CucumberContextConfiguration;
 import org.junit.jupiter.api.Test;
+import org.junit.runner.RunWith;
+import org.mifos.integrationtest.IntegrationTestApplication;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.ComponentScan;
 
 @CucumberContextConfiguration
 @CucumberOptions(publish = true)
-@SpringBootTest
+@RunWith(Cucumber.class)
+@SpringBootTest(classes = IntegrationTestApplication.class)
 public class CucumberContext {
 
     @Test

--- a/src/test/java/org/mifos/integrationtest/cucumber/CucumberContext.java
+++ b/src/test/java/org/mifos/integrationtest/cucumber/CucumberContext.java
@@ -11,8 +11,7 @@ import org.springframework.context.annotation.ComponentScan;
 
 @CucumberContextConfiguration
 @CucumberOptions(publish = true)
-@RunWith(Cucumber.class)
-@SpringBootTest(classes = IntegrationTestApplication.class)
+@SpringBootTest
 public class CucumberContext {
 
     @Test

--- a/src/test/java/org/mifos/integrationtest/cucumber/CucumberContext.java
+++ b/src/test/java/org/mifos/integrationtest/cucumber/CucumberContext.java
@@ -1,13 +1,9 @@
 package org.mifos.integrationtest.cucumber;
 
-import io.cucumber.junit.Cucumber;
 import io.cucumber.junit.CucumberOptions;
 import io.cucumber.spring.CucumberContextConfiguration;
 import org.junit.jupiter.api.Test;
-import org.junit.runner.RunWith;
-import org.mifos.integrationtest.IntegrationTestApplication;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.context.annotation.ComponentScan;
 
 @CucumberContextConfiguration
 @CucumberOptions(publish = true)


### PR DESCRIPTION
Updates in this PR
1. Removed the custom gradle task(cucumberCli) for running cucumber tests. 
2. Wired the cucumber with JUnit using custom testRunner configuration.
3. Upgraded the connector-common version to `1.5.0.
4. Fixed the tag.

Refer jira tickets [PHEE-310](https://fynarfin.atlassian.net/browse/PHEE-310) [PHEE-311](https://fynarfin.atlassian.net/browse/PHEE-311)

[PHEE-310]: https://fynarfin.atlassian.net/browse/PHEE-310?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PHEE-311]: https://fynarfin.atlassian.net/browse/PHEE-311?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ