### PR TITLE
Removed GOV tag from idempotency and get txn feature

### DIFF
--- a/src/test/java/resources/getTxn.feature
+++ b/src/test/java/resources/getTxn.feature
@@ -1,4 +1,3 @@
-@gov
 Feature: Get Txn Req API test
 
 

--- a/src/test/java/resources/idempotency.feature
+++ b/src/test/java/resources/idempotency.feature
@@ -1,4 +1,3 @@
-@gov
 Feature: Client Correlation Id Idempotency Test
 
 @application.yaml

--- a/src/test/java/resources/interopErrorCode.feature
+++ b/src/test/java/resources/interopErrorCode.feature
@@ -1,4 +1,4 @@
-@gov
+@amsintegrationtest
 Feature: Interop Error Code Test
 
   Scenario: GSMA Transfer Api PayerNotFound Test


### PR DESCRIPTION
- Collection API and GSMA transaction API is not part of GOV related.
- Operations app get txn is also not part of the GOV related so removing it.
- Errorcode testcase is bit flaky cause we need to run postman collection manually to pass this cases.