### PR TITLE
GOV-287.6 Added integration test for key-auth in bulk-processor service

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,12 @@ Use below command to execute the integration test.
 ./gradlew test -Dcucumber.filter.tags="<cucumber tag>"
 ```
 Where `<cucumber tag>` has to be replaced with valid tag, for example if you are willing to run test cases related to g2p scenario then pass the tag `@gov`. If `-Dcucumber.filter.tags` flag is omitted then all the test cases would be triggered independent of the tag.
+```shell
+* Try:
+> Run with --stacktrace option to get the stack trace.
+> Run with --debug option to get more log output.
+> Run with --scan to get full insights.
+```
 
 # Checkstyle
 Use below command to execute the checkstyle test.

--- a/src/main/java/org/mifos/integrationtest/config/BulkProcessorConfig.java
+++ b/src/main/java/org/mifos/integrationtest/config/BulkProcessorConfig.java
@@ -1,8 +1,9 @@
 package org.mifos.integrationtest.config;
 
-import javax.annotation.PostConstruct;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
+
+import javax.annotation.PostConstruct;
 
 @Component
 public class BulkProcessorConfig {

--- a/src/main/java/org/mifos/integrationtest/config/ChannelConnectorConfig.java
+++ b/src/main/java/org/mifos/integrationtest/config/ChannelConnectorConfig.java
@@ -1,8 +1,9 @@
 package org.mifos.integrationtest.config;
 
-import javax.annotation.PostConstruct;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
+
+import javax.annotation.PostConstruct;
 
 @Component
 public class ChannelConnectorConfig {

--- a/src/main/java/org/mifos/integrationtest/config/KongConfig.java
+++ b/src/main/java/org/mifos/integrationtest/config/KongConfig.java
@@ -1,0 +1,54 @@
+package org.mifos.integrationtest.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import javax.annotation.PostConstruct;
+
+@Component
+public class KongConfig {
+
+    @Value("${kong.service.host}")
+    public String serviceHost;
+
+    @Value("${kong.route.host}")
+    public String routeHost;
+
+    @Value("${kong.admin-contactpoint}")
+    public String adminContactPoint;
+
+    @Value("${kong.endpoint.consumers}")
+    public String consumerEndpoint;
+
+    @Value("${kong.endpoint.createKey}")
+    public String createKeyEndpoint;
+
+    @Value("${kong.endpoint.services}")
+    public String servicesEndpoint;
+
+    @Value("${kong.endpoint.createRoute}")
+    public String createRouteEndpoint;
+
+    @Value("${kong.endpoint.createPlugin}")
+    public String createPluginEndpoint;
+
+    @Value("${kong.endpoint.routes}")
+    public String routesEndpoint;
+
+    @Value("${kong.endpoint.plugins}")
+    public String pluginsEndpoint;
+
+    @Value("${kong.header.apikey}")
+    public String apiKeyHeader;
+
+    public String serviceUrl;
+
+    @PostConstruct
+    private void setup() {
+        serviceUrl = new StringBuilder()
+                .append("http://")
+                .append(serviceHost)
+                .append("/").toString();
+    }
+
+}

--- a/src/main/java/org/mifos/integrationtest/config/OperationsAppConfig.java
+++ b/src/main/java/org/mifos/integrationtest/config/OperationsAppConfig.java
@@ -1,8 +1,9 @@
 package org.mifos.integrationtest.config;
 
-import javax.annotation.PostConstruct;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
+
+import javax.annotation.PostConstruct;
 
 @Component
 public class OperationsAppConfig {

--- a/src/main/java/org/mifos/integrationtest/config/PaybillConfig.java
+++ b/src/main/java/org/mifos/integrationtest/config/PaybillConfig.java
@@ -1,8 +1,9 @@
 package org.mifos.integrationtest.config;
 
-import javax.annotation.PostConstruct;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
+
+import javax.annotation.PostConstruct;
 
 @Component
 public class PaybillConfig {

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -98,6 +98,6 @@ kong:
   header:
     apikey: "X-API-KEY"
   service:
-    host: "security-hello-world.dev1.8080.svc"
+    host: "ph-ee-connector-bulk.paymenthub.80.svc"
   route:
-    host: "hello-world.sandbox.fynarfin.io"
+    host: "bulk-connector.sandbox.fynarfin.io"

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -85,3 +85,19 @@ identity-account-mapper:
     account-lookup: /beneficiary
     batch-account-lookup: /accountLookup
 
+kong:
+  admin-contactpoint: "http://kong-admin.sandbox.fynarfin.io"
+  endpoint:
+    consumers: /consumers
+    createKey: /consumers/{username}/key-auth
+    services: /services
+    createRoute: /services/{serviceId}/routes
+    createPlugin: /services/{serviceId}/plugins
+    routes: /routes
+    plugins: /plugins
+  header:
+    apikey: "X-API-KEY"
+  service:
+    host: "security-hello-world.dev1.8080.svc"
+  route:
+    host: "hello-world.sandbox.fynarfin.io"

--- a/src/test/java/org/mifos/integrationtest/ClientCorrelationIdTest.java
+++ b/src/test/java/org/mifos/integrationtest/ClientCorrelationIdTest.java
@@ -1,7 +1,5 @@
 package org.mifos.integrationtest;
 
-import static com.google.common.truth.Truth.assertThat;
-
 import com.google.gson.Gson;
 import io.restassured.RestAssured;
 import io.restassured.builder.RequestSpecBuilder;
@@ -25,6 +23,8 @@ import org.mifos.integrationtest.config.OperationsAppConfig;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+
+import static com.google.common.truth.Truth.assertThat;
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class ClientCorrelationIdTest {

--- a/src/test/java/org/mifos/integrationtest/ExternalIdTest.java
+++ b/src/test/java/org/mifos/integrationtest/ExternalIdTest.java
@@ -1,7 +1,5 @@
 package org.mifos.integrationtest;
 
-import static com.google.common.truth.Truth.assertThat;
-
 import com.google.gson.Gson;
 import io.restassured.RestAssured;
 import io.restassured.builder.RequestSpecBuilder;
@@ -21,6 +19,8 @@ import org.mifos.integrationtest.common.dto.CollectionResponse;
 import org.mifos.integrationtest.common.dto.OperationsHelper;
 import org.mifos.integrationtest.common.dto.operationsapp.GetTransactionRequestResponse;
 import org.mifos.integrationtest.common.dto.operationsapp.TransactionRequest;
+
+import static com.google.common.truth.Truth.assertThat;
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class ExternalIdTest {

--- a/src/test/java/org/mifos/integrationtest/common/CollectionHelper.java
+++ b/src/test/java/org/mifos/integrationtest/common/CollectionHelper.java
@@ -1,10 +1,11 @@
 package org.mifos.integrationtest.common;
 
-import java.util.ArrayList;
-import java.util.List;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
+
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * { "payer": [ { "key": "MSISDN", "value": "254708374149" }, { "key": "ACCOUNTID", "value": "24450523" } ], "amount": {

--- a/src/test/java/org/mifos/integrationtest/common/dto/OperationsHelper.java
+++ b/src/test/java/org/mifos/integrationtest/common/dto/OperationsHelper.java
@@ -1,10 +1,11 @@
 package org.mifos.integrationtest.common.dto;
 
-import java.util.ArrayList;
-import java.util.List;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
+
+import java.util.ArrayList;
+import java.util.List;
 
 public class OperationsHelper {
 

--- a/src/test/java/org/mifos/integrationtest/common/dto/kong/KongConsumer.java
+++ b/src/test/java/org/mifos/integrationtest/common/dto/kong/KongConsumer.java
@@ -1,0 +1,22 @@
+package org.mifos.integrationtest.common.dto.kong;
+
+import io.cucumber.core.internal.com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+public class KongConsumer {
+
+    private String id;
+
+    private String username;
+
+    @JsonProperty("custom_id")
+    private String customId;
+
+}

--- a/src/test/java/org/mifos/integrationtest/common/dto/kong/KongConsumerKey.java
+++ b/src/test/java/org/mifos/integrationtest/common/dto/kong/KongConsumerKey.java
@@ -1,0 +1,17 @@
+package org.mifos.integrationtest.common.dto.kong;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+public class KongConsumerKey {
+
+    private String id;
+
+    private String key;
+}

--- a/src/test/java/org/mifos/integrationtest/common/dto/kong/KongKeyAuthPluginConfig.java
+++ b/src/test/java/org/mifos/integrationtest/common/dto/kong/KongKeyAuthPluginConfig.java
@@ -1,0 +1,16 @@
+package org.mifos.integrationtest.common.dto.kong;
+
+import io.cucumber.core.internal.com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.ArrayList;
+
+@Getter
+@Setter
+public class KongKeyAuthPluginConfig {
+
+    @JsonProperty("key_names")
+    private ArrayList<String> keyNames;
+
+}

--- a/src/test/java/org/mifos/integrationtest/common/dto/kong/KongPlugin.java
+++ b/src/test/java/org/mifos/integrationtest/common/dto/kong/KongPlugin.java
@@ -1,0 +1,24 @@
+package org.mifos.integrationtest.common.dto.kong;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.util.Map;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+public class KongPlugin {
+
+    private String id;
+
+    private String name;
+
+    private Map<String, Object> config;
+
+    private boolean enabled;
+
+}

--- a/src/test/java/org/mifos/integrationtest/common/dto/kong/KongRoute.java
+++ b/src/test/java/org/mifos/integrationtest/common/dto/kong/KongRoute.java
@@ -1,0 +1,24 @@
+package org.mifos.integrationtest.common.dto.kong;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.util.ArrayList;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+public class KongRoute {
+
+    private String id;
+
+    private String name;
+
+    private ArrayList<String> hosts;
+
+    private ArrayList<String> paths;
+
+}

--- a/src/test/java/org/mifos/integrationtest/common/dto/kong/KongService.java
+++ b/src/test/java/org/mifos/integrationtest/common/dto/kong/KongService.java
@@ -1,0 +1,20 @@
+package org.mifos.integrationtest.common.dto.kong;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+public class KongService {
+
+    private String id;
+
+    private String url;
+
+    private String name;
+
+}

--- a/src/test/java/org/mifos/integrationtest/config/MockServerConfig.java
+++ b/src/test/java/org/mifos/integrationtest/config/MockServerConfig.java
@@ -1,10 +1,10 @@
 package org.mifos.integrationtest.config;
 
-import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
-
 import com.github.tomakehurst.wiremock.WireMockServer;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Configuration;
+
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
 
 @Configuration
 public class MockServerConfig implements MockServer {

--- a/src/test/java/org/mifos/integrationtest/cucumber/stepdef/AuthStepDef.java
+++ b/src/test/java/org/mifos/integrationtest/cucumber/stepdef/AuthStepDef.java
@@ -1,16 +1,17 @@
 package org.mifos.integrationtest.cucumber.stepdef;
 
-import static com.google.common.truth.Truth.assertThat;
-
 import com.google.gson.Gson;
 import io.cucumber.java.en.Then;
 import io.cucumber.java.en.When;
 import io.restassured.RestAssured;
 import io.restassured.builder.ResponseSpecBuilder;
 import io.restassured.specification.RequestSpecification;
-import java.util.HashMap;
 import org.mifos.integrationtest.common.Utils;
 import org.springframework.beans.factory.annotation.Value;
+
+import java.util.HashMap;
+
+import static com.google.common.truth.Truth.assertThat;
 
 public class AuthStepDef extends BaseStepDef {
 

--- a/src/test/java/org/mifos/integrationtest/cucumber/stepdef/BaseStepDef.java
+++ b/src/test/java/org/mifos/integrationtest/cucumber/stepdef/BaseStepDef.java
@@ -9,13 +9,17 @@ import java.security.InvalidKeyException;
 import java.security.NoSuchAlgorithmException;
 import java.security.PublicKey;
 import java.security.cert.X509Certificate;
-import java.security.spec.InvalidKeySpecException;
 import org.apache.commons.lang3.StringUtils;
 import org.mifos.connector.common.channel.dto.TransactionChannelRequestDTO;
 import org.mifos.connector.common.util.SecurityUtil;
 import org.mifos.integrationtest.common.Utils;
 import org.mifos.integrationtest.common.dto.operationsapp.BatchDTO;
 import org.mifos.integrationtest.common.dto.operationsapp.BatchTransactionResponse;
+import org.mifos.integrationtest.common.dto.kong.KongConsumer;
+import org.mifos.integrationtest.common.dto.kong.KongConsumerKey;
+import org.mifos.integrationtest.common.dto.kong.KongPlugin;
+import org.mifos.integrationtest.common.dto.kong.KongRoute;
+import org.mifos.integrationtest.common.dto.kong.KongService;
 import org.mifos.integrationtest.config.BulkProcessorConfig;
 import org.mifos.integrationtest.config.ChannelConnectorConfig;
 import org.mifos.integrationtest.config.IdentityMapperConfig;
@@ -28,6 +32,7 @@ import org.springframework.beans.factory.annotation.Value;
 import javax.crypto.BadPaddingException;
 import javax.crypto.IllegalBlockSizeException;
 import javax.crypto.NoSuchPaddingException;
+import java.security.spec.InvalidKeySpecException;
 
 // this class is the base for all the cucumber step definitions
 public class BaseStepDef {
@@ -86,6 +91,11 @@ public class BaseStepDef {
     public static String programId;
     public static BatchDTO batchDTO;
     public static BatchTransactionResponse batchTransactionResponse;
+    protected static KongConsumer kongConsumer;
+    protected static KongConsumerKey kongConsumerKey;
+    protected static KongService kongService;
+    protected static KongRoute kongRoute;
+    protected static KongPlugin kongPlugin;
 
     // if data passed as a filename/absoluteFilePath then pass isDataAFile as true or else false
     protected String generateSignature(String clientCorrelationId, String tenant, String data, boolean isDataAFile) throws IOException,

--- a/src/test/java/org/mifos/integrationtest/cucumber/stepdef/CertificateStepDef.java
+++ b/src/test/java/org/mifos/integrationtest/cucumber/stepdef/CertificateStepDef.java
@@ -1,14 +1,15 @@
 package org.mifos.integrationtest.cucumber.stepdef;
 
-import static com.google.common.truth.Truth.assertThat;
-
 import io.cucumber.java.en.And;
 import io.cucumber.java.en.Given;
 import io.cucumber.java.en.Then;
 import io.cucumber.java.en.When;
+import org.mifos.connector.common.util.CertificateUtil;
+
 import java.security.cert.CertificateException;
 import java.security.cert.X509Certificate;
-import org.mifos.connector.common.util.CertificateUtil;
+
+import static com.google.common.truth.Truth.assertThat;
 
 public class CertificateStepDef extends BaseStepDef {
 

--- a/src/test/java/org/mifos/integrationtest/cucumber/stepdef/ChannelClientIdDef.java
+++ b/src/test/java/org/mifos/integrationtest/cucumber/stepdef/ChannelClientIdDef.java
@@ -1,7 +1,5 @@
 package org.mifos.integrationtest.cucumber.stepdef;
 
-import static com.google.common.truth.Truth.assertThat;
-
 import io.cucumber.java.en.And;
 import io.cucumber.java.en.When;
 import io.restassured.RestAssured;
@@ -11,6 +9,8 @@ import org.mifos.integrationtest.common.Utils;
 import org.mifos.integrationtest.config.ChannelConnectorConfig;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
+
+import static com.google.common.truth.Truth.assertThat;
 
 public class ChannelClientIdDef extends BaseStepDef {
 

--- a/src/test/java/org/mifos/integrationtest/cucumber/stepdef/ContextStepDef.java
+++ b/src/test/java/org/mifos/integrationtest/cucumber/stepdef/ContextStepDef.java
@@ -1,11 +1,11 @@
 package org.mifos.integrationtest.cucumber.stepdef;
 
-import static com.google.common.truth.Truth.assertThat;
-
 import io.cucumber.java.en.Given;
 import io.cucumber.java.en.Then;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationContext;
+
+import static com.google.common.truth.Truth.assertThat;
 
 public class ContextStepDef extends BaseStepDef {
 

--- a/src/test/java/org/mifos/integrationtest/cucumber/stepdef/ErrorCodeStepDef.java
+++ b/src/test/java/org/mifos/integrationtest/cucumber/stepdef/ErrorCodeStepDef.java
@@ -1,7 +1,5 @@
 package org.mifos.integrationtest.cucumber.stepdef;
 
-import static com.google.common.truth.Truth.assertThat;
-
 import io.cucumber.core.internal.com.fasterxml.jackson.core.JsonProcessingException;
 import io.cucumber.core.internal.com.fasterxml.jackson.databind.JsonMappingException;
 import io.cucumber.java.en.And;
@@ -28,6 +26,8 @@ import org.mifos.connector.common.gsma.dto.SubjectName;
 import org.mifos.integrationtest.common.GSMATransferHelper;
 import org.mifos.integrationtest.common.Utils;
 import org.springframework.beans.factory.annotation.Value;
+
+import static com.google.common.truth.Truth.assertThat;
 
 public class ErrorCodeStepDef extends BaseStepDef {
 

--- a/src/test/java/org/mifos/integrationtest/cucumber/stepdef/GSMATransferStepDef.java
+++ b/src/test/java/org/mifos/integrationtest/cucumber/stepdef/GSMATransferStepDef.java
@@ -1,10 +1,5 @@
 package org.mifos.integrationtest.cucumber.stepdef;
 
-import static com.google.common.truth.Truth.assertThat;
-import static org.mifos.integrationtest.common.Utils.CONTENT_TYPE;
-import static org.mifos.integrationtest.common.Utils.CONTENT_TYPE_VALUE;
-import static org.mifos.integrationtest.common.Utils.X_CORRELATIONID;
-
 import io.cucumber.core.internal.com.fasterxml.jackson.core.JsonProcessingException;
 import io.cucumber.core.internal.com.fasterxml.jackson.databind.ObjectMapper;
 import io.cucumber.java.en.And;
@@ -15,12 +10,15 @@ import io.restassured.RestAssured;
 import io.restassured.builder.ResponseSpecBuilder;
 import io.restassured.specification.RequestSpecification;
 import org.apache.fineract.client.models.PostSavingsAccountsResponse;
-import org.mifos.integrationtest.common.Utils;
 import org.apache.fineract.client.models.PostSelfLoansLoanIdResponse;
+import org.mifos.integrationtest.common.Utils;
 import org.mifos.integrationtest.config.GsmaConfig;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.mifos.integrationtest.common.Utils.*;
 
 public class GSMATransferStepDef {
 

--- a/src/test/java/org/mifos/integrationtest/cucumber/stepdef/GetTxnApiDef.java
+++ b/src/test/java/org/mifos/integrationtest/cucumber/stepdef/GetTxnApiDef.java
@@ -1,7 +1,5 @@
 package org.mifos.integrationtest.cucumber.stepdef;
 
-import static com.google.common.truth.Truth.assertThat;
-
 import com.google.gson.Gson;
 import io.cucumber.java.en.And;
 import io.cucumber.java.en.When;
@@ -14,6 +12,8 @@ import org.mifos.integrationtest.common.CollectionHelper;
 import org.mifos.integrationtest.common.Utils;
 import org.mifos.integrationtest.common.dto.CollectionResponse;
 import org.springframework.beans.factory.annotation.Value;
+
+import static com.google.common.truth.Truth.assertThat;
 
 public class GetTxnApiDef extends BaseStepDef {
 

--- a/src/test/java/org/mifos/integrationtest/cucumber/stepdef/IdempotencyStepDef.java
+++ b/src/test/java/org/mifos/integrationtest/cucumber/stepdef/IdempotencyStepDef.java
@@ -1,10 +1,5 @@
 package org.mifos.integrationtest.cucumber.stepdef;
 
-import static com.google.common.truth.Truth.assertThat;
-import static org.mifos.integrationtest.common.Utils.CONTENT_TYPE;
-import static org.mifos.integrationtest.common.Utils.CONTENT_TYPE_VALUE;
-import static org.mifos.integrationtest.common.Utils.X_CORRELATIONID;
-
 import com.google.gson.Gson;
 import io.cucumber.core.internal.com.fasterxml.jackson.core.JsonProcessingException;
 import io.cucumber.java.en.And;
@@ -13,7 +8,6 @@ import io.cucumber.java.en.When;
 import io.restassured.RestAssured;
 import io.restassured.builder.ResponseSpecBuilder;
 import io.restassured.specification.RequestSpecification;
-import java.util.UUID;
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.mifos.integrationtest.common.CollectionHelper;
@@ -21,6 +15,11 @@ import org.mifos.integrationtest.common.Utils;
 import org.mifos.integrationtest.common.dto.CollectionResponse;
 import org.mifos.integrationtest.config.GsmaConfig;
 import org.springframework.beans.factory.annotation.Autowired;
+
+import java.util.UUID;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.mifos.integrationtest.common.Utils.*;
 
 public class IdempotencyStepDef extends BaseStepDef {
 

--- a/src/test/java/org/mifos/integrationtest/cucumber/stepdef/IdentityMapperStepDef.java
+++ b/src/test/java/org/mifos/integrationtest/cucumber/stepdef/IdentityMapperStepDef.java
@@ -2,13 +2,10 @@ package org.mifos.integrationtest.cucumber.stepdef;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.*;
 import static com.google.common.truth.Truth.assertThat;
-import static org.mifos.integrationtest.common.HttpMethod.PUT;
-
 import com.github.tomakehurst.wiremock.stubbing.ServeEvent;
 import io.cucumber.core.internal.com.fasterxml.jackson.core.JsonProcessingException;
 import io.cucumber.core.internal.com.fasterxml.jackson.databind.JsonNode;
 import io.cucumber.java.en.And;
-import io.cucumber.java.en.Given;
 import io.cucumber.java.en.Then;
 import io.cucumber.java.en.When;
 import io.restassured.RestAssured;
@@ -16,7 +13,6 @@ import io.restassured.builder.ResponseSpecBuilder;
 import io.restassured.specification.RequestSpecification;
 import java.io.File;
 import java.util.*;
-
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -24,6 +20,10 @@ import org.mifos.connector.common.channel.dto.TransactionChannelRequestDTO;
 import org.mifos.connector.common.identityaccountmapper.dto.AccountMapperRequestDTO;
 import org.mifos.connector.common.identityaccountmapper.dto.BeneficiaryDTO;
 import org.mifos.integrationtest.common.Utils;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+import java.util.UUID;
 
 public class IdentityMapperStepDef extends BaseStepDef {
 

--- a/src/test/java/org/mifos/integrationtest/cucumber/stepdef/InboundStepDef.java
+++ b/src/test/java/org/mifos/integrationtest/cucumber/stepdef/InboundStepDef.java
@@ -1,7 +1,5 @@
 package org.mifos.integrationtest.cucumber.stepdef;
 
-import static com.google.common.truth.Truth.assertThat;
-
 import io.cucumber.core.internal.com.fasterxml.jackson.core.JsonProcessingException;
 import io.cucumber.java.en.And;
 import io.cucumber.java.en.Given;
@@ -13,6 +11,8 @@ import org.json.JSONException;
 import org.json.JSONObject;
 import org.mifos.connector.common.channel.dto.TransactionChannelRequestDTO;
 import org.mifos.integrationtest.common.Utils;
+
+import static com.google.common.truth.Truth.assertThat;
 
 public class InboundStepDef extends BaseStepDef {
 

--- a/src/test/java/org/mifos/integrationtest/cucumber/stepdef/JWSStepDef.java
+++ b/src/test/java/org/mifos/integrationtest/cucumber/stepdef/JWSStepDef.java
@@ -1,26 +1,22 @@
 package org.mifos.integrationtest.cucumber.stepdef;
 
-import static com.google.common.truth.Truth.assertThat;
-
 import io.cucumber.java.en.And;
+import org.mifos.connector.common.util.CertificateUtil;
+import org.mifos.connector.common.util.Constant;
+import org.mifos.connector.common.util.SecurityUtil;
+import org.mifos.integrationtest.config.JWSKeyConfig;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import javax.crypto.BadPaddingException;
+import javax.crypto.IllegalBlockSizeException;
+import javax.crypto.NoSuchPaddingException;
 import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Paths;
 import java.security.InvalidKeyException;
 import java.security.NoSuchAlgorithmException;
 import java.security.cert.CertificateException;
 import java.security.spec.InvalidKeySpecException;
-import javax.crypto.BadPaddingException;
-import javax.crypto.IllegalBlockSizeException;
-import javax.crypto.NoSuchPaddingException;
 
-import org.apache.commons.lang3.StringUtils;
-import org.mifos.connector.common.util.CertificateUtil;
-import org.mifos.connector.common.util.Constant;
-import org.mifos.connector.common.util.SecurityUtil;
-import org.mifos.integrationtest.common.Utils;
-import org.mifos.integrationtest.config.JWSKeyConfig;
-import org.springframework.beans.factory.annotation.Autowired;
+import static com.google.common.truth.Truth.assertThat;
 
 public class JWSStepDef extends BaseStepDef {
 

--- a/src/test/java/org/mifos/integrationtest/cucumber/stepdef/KongStepDef.java
+++ b/src/test/java/org/mifos/integrationtest/cucumber/stepdef/KongStepDef.java
@@ -178,7 +178,7 @@ public class KongStepDef extends BaseStepDef {
         RequestSpecification baseReqSpec = Utils.getDefaultSpec();
         try {
             Response resp = RestAssured.given(baseReqSpec)
-                    .baseUri("http://"+kongConfig.routeHost)
+                    .baseUri("https://"+kongConfig.routeHost)
                     .header(kongConfig.apiKeyHeader, BaseStepDef.kongConsumerKey.getKey())
                     .expect()
                     .spec(new ResponseSpecBuilder().expectStatusCode(expectedStatus).build())

--- a/src/test/java/org/mifos/integrationtest/cucumber/stepdef/KongStepDef.java
+++ b/src/test/java/org/mifos/integrationtest/cucumber/stepdef/KongStepDef.java
@@ -118,7 +118,7 @@ public class KongStepDef extends BaseStepDef {
         KongRoute route = new KongRoute();
         route.setId(UUID.randomUUID().toString());
         route.setName("name_"+route.getId());
-        route.setPaths(new ArrayList<>(){{ add("/"); }});
+        route.setPaths(new ArrayList<>(){{ add("/actuator/health/liveness"); }});
         route.setHosts(new ArrayList<>(){{ add(kongConfig.routeHost); }});
 
         RequestSpecification baseReqSpec = Utils.getDefaultSpec();
@@ -183,7 +183,7 @@ public class KongStepDef extends BaseStepDef {
                     .expect()
                     .spec(new ResponseSpecBuilder().expectStatusCode(expectedStatus).build())
                     .when()
-                    .get().andReturn();
+                    .get("/actuator/health/liveness").andReturn();
             BaseStepDef.response = resp.asString();
 
             logger.debug("Status Code: {}", resp.getStatusCode());

--- a/src/test/java/org/mifos/integrationtest/cucumber/stepdef/KongStepDef.java
+++ b/src/test/java/org/mifos/integrationtest/cucumber/stepdef/KongStepDef.java
@@ -1,0 +1,269 @@
+package org.mifos.integrationtest.cucumber.stepdef;
+
+import io.cucumber.core.internal.com.fasterxml.jackson.core.JsonProcessingException;
+import io.cucumber.java.After;
+import io.cucumber.java.en.And;
+import io.cucumber.java.en.Given;
+import io.cucumber.java.en.Then;
+import io.cucumber.java.en.When;
+import io.restassured.RestAssured;
+import io.restassured.builder.ResponseSpecBuilder;
+import io.restassured.response.Response;
+import io.restassured.specification.RequestSpecification;
+import org.mifos.integrationtest.common.Utils;
+import org.mifos.integrationtest.common.dto.kong.KongConsumer;
+import org.mifos.integrationtest.common.dto.kong.KongConsumerKey;
+import org.mifos.integrationtest.common.dto.kong.KongPlugin;
+import org.mifos.integrationtest.common.dto.kong.KongRoute;
+import org.mifos.integrationtest.common.dto.kong.KongService;
+import org.mifos.integrationtest.config.KongConfig;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.UUID;
+
+import static com.google.common.truth.Truth.assertThat;
+
+public class KongStepDef extends BaseStepDef {
+
+    @Autowired
+    public KongConfig kongConfig;
+
+    @Given("I have required Kong configuration")
+    public void checkKongConfigNotNull() {
+        assertThat(this.kongConfig).isNotNull();
+    }
+
+    @When("I create new consumer")
+    public void createNewConsumer() throws JsonProcessingException {
+        KongConsumer consumer = new KongConsumer();
+        consumer.setCustomId("custom_"+System.currentTimeMillis());
+        consumer.setId(UUID.randomUUID().toString());
+        consumer.setUsername("user_"+System.currentTimeMillis());
+
+        RequestSpecification baseReqSpec = Utils.getDefaultSpec();
+
+        BaseStepDef.response = RestAssured.given(baseReqSpec)
+                .baseUri(kongConfig.adminContactPoint)
+                .header("Content-Type", "application/json")
+                .body(objectMapper.writeValueAsString(consumer)).expect()
+                .spec(new ResponseSpecBuilder().expectStatusCode(201).build()).when()
+                .post(kongConfig.consumerEndpoint).andReturn().asString();
+
+        logger.debug("Create new consumer response from kong: {}", BaseStepDef.response);
+        try {
+            BaseStepDef.kongConsumer = objectMapper.readValue(BaseStepDef.response, KongConsumer.class);
+            logger.debug("Kong consumer: {}", objectMapper.writeValueAsString(BaseStepDef.kongConsumer));
+        } catch (Exception e) {
+            BaseStepDef.kongConsumer = null;
+        }
+
+        assertThat(BaseStepDef.kongConsumer).isNotNull();
+    }
+
+    @And("I am able to create a key for above consumer")
+    public void createKey() throws JsonProcessingException {
+        KongConsumerKey consumerKey = new KongConsumerKey();
+        consumerKey.setKey(UUID.randomUUID().toString());
+        consumerKey.setId(UUID.randomUUID().toString());
+
+        RequestSpecification baseReqSpec = Utils.getDefaultSpec();
+        BaseStepDef.response = RestAssured.given(baseReqSpec)
+                .baseUri(kongConfig.adminContactPoint)
+                .header("Content-Type", "application/json")
+                .body(objectMapper.writeValueAsString(consumerKey)).expect()
+                .spec(new ResponseSpecBuilder().expectStatusCode(201).build()).when()
+                .post(kongConfig.createKeyEndpoint, BaseStepDef.kongConsumer.getUsername()).andReturn().asString();
+
+        logger.debug("Create new key response from kong: {}", BaseStepDef.response);
+        try {
+            BaseStepDef.kongConsumerKey = objectMapper.readValue(BaseStepDef.response, KongConsumerKey.class);
+            logger.debug("Kong consumer key: {}", objectMapper.writeValueAsString(BaseStepDef.kongConsumerKey));
+        } catch (Exception e) {
+            BaseStepDef.kongConsumerKey = null;
+        }
+
+        assertThat(BaseStepDef.kongConsumerKey).isNotNull();
+    }
+
+    @And("I register a service in kong")
+    public void registerService() throws JsonProcessingException {
+        KongService service = new KongService();
+        service.setId(UUID.randomUUID().toString());
+        service.setUrl(kongConfig.serviceUrl);
+        service.setName("name_"+service.getId());
+
+        RequestSpecification baseReqSpec = Utils.getDefaultSpec();
+        BaseStepDef.response = RestAssured.given(baseReqSpec)
+                .baseUri(kongConfig.adminContactPoint)
+                .header("Content-Type", "application/json")
+                .body(objectMapper.writeValueAsString(service)).expect()
+                .spec(new ResponseSpecBuilder().expectStatusCode(201).build()).when()
+                .post(kongConfig.servicesEndpoint).andReturn().asString();
+
+        logger.debug("Create new service response from kong: {}", BaseStepDef.response);
+        try {
+            BaseStepDef.kongService = objectMapper.readValue(BaseStepDef.response, KongService.class);
+            logger.debug("Kong service: {}", objectMapper.writeValueAsString(BaseStepDef.kongService));
+        } catch (Exception e) {
+            BaseStepDef.kongService = null;
+        }
+
+        assertThat(BaseStepDef.kongService).isNotNull();
+    }
+
+    @And("I register a route to above service in kong")
+    public void registerRouteInService() throws JsonProcessingException {
+        KongRoute route = new KongRoute();
+        route.setId(UUID.randomUUID().toString());
+        route.setName("name_"+route.getId());
+        route.setPaths(new ArrayList<>(){{ add("/"); }});
+        route.setHosts(new ArrayList<>(){{ add(kongConfig.routeHost); }});
+
+        RequestSpecification baseReqSpec = Utils.getDefaultSpec();
+        BaseStepDef.response = RestAssured.given(baseReqSpec)
+                .baseUri(kongConfig.adminContactPoint)
+                .header("Content-Type", "application/json")
+                .body(objectMapper.writeValueAsString(route)).expect()
+                .spec(new ResponseSpecBuilder().expectStatusCode(201).build()).when()
+                .post(kongConfig.createRouteEndpoint, BaseStepDef.kongService.getId()).andReturn().asString();
+
+        logger.debug("Create new route response from kong: {}", BaseStepDef.response);
+        try {
+            BaseStepDef.kongRoute = objectMapper.readValue(BaseStepDef.response, KongRoute.class);
+            logger.debug("Kong route: {}", objectMapper.writeValueAsString(BaseStepDef.kongRoute));
+        } catch (Exception e) {
+            BaseStepDef.kongRoute = null;
+        }
+
+        assertThat(BaseStepDef.kongRoute).isNotNull();
+    }
+
+    @And("I add the key-auth plugin in above service")
+    public void enableKeyAuthPlugin() throws JsonProcessingException {
+        KongPlugin kongPlugin = new KongPlugin();
+        kongPlugin.setId(UUID.randomUUID().toString());
+        kongPlugin.setName("key-auth");
+        kongPlugin.setEnabled(true);
+        kongPlugin.setConfig(new HashMap<>(){{
+            put("key_names", new ArrayList<String>(){{
+                add(kongConfig.apiKeyHeader);
+            }});
+        }});
+
+        RequestSpecification baseReqSpec = Utils.getDefaultSpec();
+        BaseStepDef.response = RestAssured.given(baseReqSpec)
+                .baseUri(kongConfig.adminContactPoint)
+                .header("Content-Type", "application/json")
+                .body(objectMapper.writeValueAsString(kongPlugin)).expect()
+                .spec(new ResponseSpecBuilder().expectStatusCode(201).build()).when()
+                .post(kongConfig.createPluginEndpoint, BaseStepDef.kongService.getId()).andReturn().asString();
+
+        logger.debug("Enable key-auth plugin response from kong: {}", BaseStepDef.response);
+        try {
+            BaseStepDef.kongPlugin = objectMapper.readValue(BaseStepDef.response, KongPlugin.class);
+            logger.debug("Kong plugin: {}", objectMapper.writeValueAsString(BaseStepDef.kongPlugin));
+        } catch (Exception e) {
+            BaseStepDef.kongPlugin = null;
+        }
+
+        assertThat(BaseStepDef.kongPlugin).isNotNull();
+    }
+
+    @Then("When I call the service endpoint with api key I should get {int}")
+    public void callServiceEndpoint(int expectedStatus) {
+        logger.debug("Key: {}", BaseStepDef.kongConsumerKey.getKey());
+        logger.debug("Host: {}", kongConfig.routeHost);
+        RequestSpecification baseReqSpec = Utils.getDefaultSpec();
+        try {
+            Response resp = RestAssured.given(baseReqSpec)
+                    .baseUri("http://"+kongConfig.routeHost)
+                    .header(kongConfig.apiKeyHeader, BaseStepDef.kongConsumerKey.getKey())
+                    .expect()
+                    .spec(new ResponseSpecBuilder().expectStatusCode(expectedStatus).build())
+                    .when()
+                    .get().andReturn();
+            BaseStepDef.response = resp.asString();
+
+            logger.debug("Status Code: {}", resp.getStatusCode());
+            logger.debug("Response: {}", BaseStepDef.response);
+        } catch (Exception e) {
+            e.printStackTrace();
+            clearKongData();
+        }
+    }
+
+    @After("@kong-teardown")
+    public void removeKeyAuth() {
+        logger.debug("Running kong teardown");
+        clearKongData();
+    }
+
+    @And("I wait for {int} seconds")
+    public void waitForSometime(int seconds) {
+        Utils.sleep(seconds);
+    }
+
+    // cals respective methods for clearing kong related resources
+    private void clearKongData() {
+        if (BaseStepDef.kongConsumer != null) {
+            deleteConsumer(BaseStepDef.kongConsumer.getId());
+            BaseStepDef.kongConsumer = null;
+            BaseStepDef.kongConsumerKey = null;
+        }
+        if (BaseStepDef.kongPlugin != null) {
+            deletePlugin(BaseStepDef.kongPlugin.getId());
+            BaseStepDef.kongPlugin= null;
+        }
+        if (BaseStepDef.kongRoute != null) {
+            deleteRoute(BaseStepDef.kongRoute.getId());
+            BaseStepDef.kongRoute = null;
+        }
+        if (BaseStepDef.kongService != null) {
+            deleteService(BaseStepDef.kongService.getId());
+            BaseStepDef.kongService = null;
+        }
+    }
+
+    // deletes the consumer in kong by calling admin api
+    private void deleteConsumer(String consumerId) {
+        RequestSpecification baseReqSpec = Utils.getDefaultSpec();
+        String deleteResponse = RestAssured.given(baseReqSpec)
+                .baseUri(kongConfig.adminContactPoint)
+                .delete(kongConfig.consumerEndpoint+"/{consumerId}",consumerId)
+                .andReturn().asString();
+        logger.debug("Consumer delete response: {}", deleteResponse);
+    }
+
+    // deletes the plugin in kong by calling admin api
+    private void deletePlugin(String pluginId) {
+        RequestSpecification baseReqSpec = Utils.getDefaultSpec();
+        String deleteResponse = RestAssured.given(baseReqSpec)
+                .baseUri(kongConfig.adminContactPoint)
+                .delete(kongConfig.pluginsEndpoint+"/{pluginId}",pluginId)
+                .andReturn().asString();
+        logger.debug("Plugin delete response: {}", deleteResponse);
+    }
+
+    // deletes the route in kong by calling admin api
+    private void deleteRoute(String routeId) {
+        RequestSpecification baseReqSpec = Utils.getDefaultSpec();
+        String deleteResponse = RestAssured.given(baseReqSpec)
+                .baseUri(kongConfig.adminContactPoint)
+                .delete(kongConfig.routesEndpoint+"/{routeId}",routeId)
+                .andReturn().asString();
+        logger.debug("Route delete response: {}", deleteResponse);
+    }
+
+    // deletes the service in kong by calling admin api
+    private void deleteService(String serviceId) {
+        RequestSpecification baseReqSpec = Utils.getDefaultSpec();
+        String deleteResponse = RestAssured.given(baseReqSpec)
+                .baseUri(kongConfig.adminContactPoint)
+                .delete(kongConfig.servicesEndpoint+"/{serviceId}",serviceId)
+                .andReturn().asString();
+        logger.debug("Service delete response: {}", deleteResponse);
+    }
+
+}

--- a/src/test/java/org/mifos/integrationtest/cucumber/stepdef/MockServerStepDef.java
+++ b/src/test/java/org/mifos/integrationtest/cucumber/stepdef/MockServerStepDef.java
@@ -1,9 +1,5 @@
 package org.mifos.integrationtest.cucumber.stepdef;
 
-import static com.github.tomakehurst.wiremock.client.WireMock.*;
-import static com.google.common.truth.Truth.assertThat;
-import static org.mifos.integrationtest.common.Utils.getDefaultSpec;
-
 import io.cucumber.java.ParameterType;
 import io.cucumber.java.en.And;
 import io.cucumber.java.en.Given;
@@ -14,6 +10,10 @@ import io.restassured.builder.ResponseSpecBuilder;
 import io.restassured.specification.RequestSender;
 import org.mifos.integrationtest.common.HttpMethod;
 import org.springframework.beans.factory.annotation.Value;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.*;
+import static com.google.common.truth.Truth.assertThat;
+import static org.mifos.integrationtest.common.Utils.getDefaultSpec;
 
 public class MockServerStepDef extends BaseStepDef {
     private static Boolean wiremockStarted = false;

--- a/src/test/java/org/mifos/integrationtest/cucumber/stepdef/PaybillApiStepDef.java
+++ b/src/test/java/org/mifos/integrationtest/cucumber/stepdef/PaybillApiStepDef.java
@@ -1,9 +1,5 @@
 package org.mifos.integrationtest.cucumber.stepdef;
 
-import static com.google.common.truth.Truth.assertThat;
-import static org.mifos.integrationtest.common.Utils.CONTENT_TYPE;
-import static org.mifos.integrationtest.common.Utils.CONTENT_TYPE_VALUE;
-
 import io.cucumber.core.internal.com.fasterxml.jackson.databind.ObjectMapper;
 import io.cucumber.java.en.And;
 import io.cucumber.java.en.Given;
@@ -18,6 +14,10 @@ import org.mifos.integrationtest.config.PaybillConfig;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.mifos.integrationtest.common.Utils.CONTENT_TYPE;
+import static org.mifos.integrationtest.common.Utils.CONTENT_TYPE_VALUE;
 
 public class PaybillApiStepDef {
 

--- a/src/test/java/org/mifos/integrationtest/cucumber/stepdef/SecurityUtilStepDef.java
+++ b/src/test/java/org/mifos/integrationtest/cucumber/stepdef/SecurityUtilStepDef.java
@@ -1,21 +1,22 @@
 package org.mifos.integrationtest.cucumber.stepdef;
 
-import static com.google.common.truth.Truth.assertThat;
-
 import io.cucumber.java.en.And;
 import io.cucumber.java.en.Given;
 import io.cucumber.java.en.Then;
 import io.cucumber.java.en.When;
+import org.mifos.connector.common.util.SecurityUtil;
+import org.mifos.integrationtest.config.JWSKeyConfig;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import javax.crypto.BadPaddingException;
+import javax.crypto.IllegalBlockSizeException;
+import javax.crypto.NoSuchPaddingException;
 import java.security.InvalidKeyException;
 import java.security.NoSuchAlgorithmException;
 import java.security.spec.InvalidKeySpecException;
 import java.util.UUID;
-import javax.crypto.BadPaddingException;
-import javax.crypto.IllegalBlockSizeException;
-import javax.crypto.NoSuchPaddingException;
-import org.mifos.connector.common.util.SecurityUtil;
-import org.mifos.integrationtest.config.JWSKeyConfig;
-import org.springframework.beans.factory.annotation.Autowired;
+
+import static com.google.common.truth.Truth.assertThat;
 
 public class SecurityUtilStepDef extends BaseStepDef {
 

--- a/src/test/java/org/mifos/integrationtest/cucumber/stepdef/validateTxnDef.java
+++ b/src/test/java/org/mifos/integrationtest/cucumber/stepdef/validateTxnDef.java
@@ -1,10 +1,10 @@
 package org.mifos.integrationtest.cucumber.stepdef;
 
-import static com.google.common.truth.Truth.assertThat;
-
 import io.cucumber.core.internal.com.fasterxml.jackson.core.JsonProcessingException;
 import io.cucumber.java.en.Given;
 import org.mifos.connector.common.channel.dto.TransactionChannelRequestDTO;
+
+import static com.google.common.truth.Truth.assertThat;
 
 public class validateTxnDef extends BaseStepDef {
 

--- a/src/test/java/resources/kongSecurity.feature
+++ b/src/test/java/resources/kongSecurity.feature
@@ -1,0 +1,13 @@
+@gov-security
+Feature: Kong security test
+
+  @kong-teardown
+  Scenario: API-KEY authentication test
+    Given I have required Kong configuration
+    When I create new consumer
+    And I am able to create a key for above consumer
+    And I register a service in kong
+    And I register a route to above service in kong
+    And I add the key-auth plugin in above service
+    And I wait for 5 seconds
+    Then When I call the service endpoint with api key I should get 200

--- a/src/test/java/resources/kongSecurity.feature
+++ b/src/test/java/resources/kongSecurity.feature
@@ -5,9 +5,13 @@ Feature: Kong security test
   Scenario: API-KEY authentication test
     Given I have required Kong configuration
     When I create new consumer
+    And I wait for 2 seconds
     And I am able to create a key for above consumer
+    And I wait for 2 seconds
     And I register a service in kong
+    And I wait for 2 seconds
     And I register a route to above service in kong
+    And I wait for 2 seconds
     And I add the key-auth plugin in above service
     And I wait for 5 seconds
     Then When I call the service endpoint with api key I should get 200


### PR DESCRIPTION
Updates in this PR
1. Added integration test for kong key-auth in hello-world service.
2. Created these steps service -> Create Route -> Create Plugin
3. Mapped the consumer to the service.
4. Teardown the entire step.


JIRA -> [GOV-287](https://mifosforge.jira.com/browse/GOV-287)

[GOV-287]: https://mifosforge.jira.com/browse/GOV-287?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ