### PR TITLE
GOV-449: Zeebe kafka test

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -166,6 +166,7 @@ dependencies {
     implementation 'com.diffplug.gradle.spotless:spotless:2.4.1'
     implementation 'com.diffplug.spotless:spotless-plugin-gradle:6.17.0'
     implementation 'org.mifos:openapi-java-client:2.0.3-SNAPSHOT'
+    testImplementation 'org.springframework.kafka:spring-kafka:2.8.7'
 }
 
 tasks.named('test') {

--- a/src/main/java/org/mifos/integrationtest/config/KafkaConfig.java
+++ b/src/main/java/org/mifos/integrationtest/config/KafkaConfig.java
@@ -1,0 +1,17 @@
+package org.mifos.integrationtest.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Component
+public class KafkaConfig {
+
+    @Value("${kafka.brokers}")
+    public String kafkaBroker;
+
+    @Value("${kafka.topic}")
+    public String kafkaTopic;
+
+    @Value("${kafka.consumerTimeoutMs}")
+    public String consumerTimeoutMs;
+}

--- a/src/main/java/org/mifos/integrationtest/config/ZeebeOperationsConfig.java
+++ b/src/main/java/org/mifos/integrationtest/config/ZeebeOperationsConfig.java
@@ -1,0 +1,26 @@
+package org.mifos.integrationtest.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Component
+public class ZeebeOperationsConfig {
+
+    @Value("${zeebe-operations.contactpoint}")
+    public String zeebeOperationContactPoint;
+
+    @Value("${zeebe-operations.endpoints.workflow}")
+    public String workflowEndpoint;
+
+    @Value("${zeebe-operations.endpoints.upload-bpmn}")
+    public String uploadBpmnEndpoint;
+
+    @Value("${zeebe-operations.no-of-workflows}")
+    public int noOfWorkflows;
+
+    @Value("${zeebe-test.enabled}")
+    public boolean enabled;
+
+    @Value("${zeebe-operations.thread-count}")
+    public int threadCount;
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -34,6 +34,7 @@ channel-connector:
     gsma-p2p: "/channel/gsma/transfer"
     collection: "/channel/collection"
     transferReq: "/channel/transactionRequest"
+    international-remittance: "/channel/gsma/deposit"
 
 max-retry-count: 5
 retry-interval: 15000
@@ -79,3 +80,19 @@ identity-account-mapper:
     add-payment-modality: /paymentModality
     update-payment-modality: /paymentModality
     account-lookup: /beneficiary
+
+kafka:
+  brokers: "kafka:9092"
+  topic: "zeebe-export"
+  consumerTimeoutMs: 6000
+
+zeebe-test:
+  enabled: true
+
+zeebe-operations:
+  contactpoint: "https://zeebeops2.sandbox.fynarfin.io"
+  endpoints:
+    workflow: "/channel/workflow/"
+    upload-bpmn: "/zeebe/upload"
+  no-of-workflows : 10
+  thread-count: 5

--- a/src/test/java/org/mifos/integrationtest/cucumber/stepdef/ZeebeStepDef.java
+++ b/src/test/java/org/mifos/integrationtest/cucumber/stepdef/ZeebeStepDef.java
@@ -1,0 +1,192 @@
+package org.mifos.integrationtest.cucumber.stepdef;
+
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import io.cucumber.java.en.And;
+import io.cucumber.java.en.Then;
+import io.cucumber.java.en.When;
+import io.restassured.RestAssured;
+import io.restassured.builder.MultiPartSpecBuilder;
+import io.restassured.builder.ResponseSpecBuilder;
+import io.restassured.specification.MultiPartSpecification;
+import io.restassured.specification.RequestSpecification;
+import org.apache.commons.io.IOUtils;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.consumer.ConsumerRecords;
+import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.mifos.integrationtest.common.Utils;
+import org.mifos.integrationtest.config.KafkaConfig;
+import org.mifos.integrationtest.config.ZeebeOperationsConfig;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.*;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
+import static com.google.common.truth.Truth.assertThat;
+
+public class ZeebeStepDef extends BaseStepDef {
+
+    @Autowired
+    ZeebeOperationsConfig zeebeOperationsConfig;
+
+    @Autowired
+    KafkaConfig kafkaConfig;
+
+    private Set<String> processInstanceKeySet = new HashSet<>();
+
+    private Set<String> kafkaPollProcessInstanceKeySet = new HashSet<>();
+
+    private static final String BPMN_FILE_URL =
+            "https://raw.githubusercontent.com/arkadasfynarfin/ph-ee-env-labs/zeebe-upgrade-2/orchestration/feel/zeebetest.bpmn";
+
+    Logger logger = LoggerFactory.getLogger(this.getClass());
+
+    @When("I upload the BPMN file to zeebe")
+    public void uploadBpmnFileToZeebe() throws MalformedURLException {
+        String fileContent = getFileContent(BPMN_FILE_URL);
+        BaseStepDef.response = uploadBPMNFile(fileContent);
+        logger.info("BPMN file upload response: {}", BaseStepDef.response);
+    }
+
+    @And("I can start test workflow n times with message {string} and listen on kafka topic")
+    public void iCanStartTestWorkflowNTimesWithMessage(String message) {
+        logger.info("Test workflow started");
+        String requestBody = String.format("{ \"message\": \"%s\" }", message);
+        String endpoint= zeebeOperationsConfig.workflowEndpoint +"zeebetest";
+
+        ExecutorService apiExecutorService = Executors.newFixedThreadPool(zeebeOperationsConfig.threadCount);
+        KafkaConsumer<String, String> consumer = createKafkaConsumer();
+        consumer.subscribe(Collections.singletonList(kafkaConfig.kafkaTopic));
+
+        for (int i=0; i<zeebeOperationsConfig.noOfWorkflows;i++) {
+            final int workflowNumber = i;
+            apiExecutorService.execute(() -> {
+                BaseStepDef.response = sendWorkflowRequest(endpoint, requestBody);
+                JsonObject payload = JsonParser.parseString(BaseStepDef.response).getAsJsonObject();
+                String processInstanceKey = payload.get("processInstanceKey").getAsString();
+                processInstanceKeySet.add(processInstanceKey);
+                logger.info("Workflow Response {}: {}", workflowNumber, processInstanceKey);
+            });
+            ConsumerRecords<String, String> records = consumer.poll(Duration.ofMillis(100));
+            logger.info("No. of records received: {}", records.count());
+
+            if (!records.isEmpty()) {
+                processKafkaRecords(records);
+            }
+        }
+
+        apiExecutorService.shutdown();
+        try {
+            apiExecutorService.awaitTermination(Integer.MAX_VALUE, TimeUnit.MICROSECONDS);
+        } catch (InterruptedException e) {
+            e.printStackTrace();
+        }
+
+        logger.info("Additional consumer polls");
+        long timeout = Long.parseLong(kafkaConfig.consumerTimeoutMs);
+        long startTime = System.currentTimeMillis();
+
+        while(processInstanceKeySet.size() > 0){
+            ConsumerRecords<String, String> records = consumer.poll(Duration.ofMillis(100));
+            if(!records.isEmpty()){
+                logger.info("No. of additional records received: {}", records.count());
+                processKafkaRecords(records);
+            }
+
+            if (System.currentTimeMillis() - startTime >= timeout) {
+                logger.info("Timeout reached. Exiting loop.");
+                break;
+            }
+        }
+
+        logger.info("Test workflow ended");
+    }
+
+    @Then("The number of workflows started should be equal to number of message consumed from kafka topic")
+    public void verifyNumberOfWorkflowsStartedEqualsNumberOfMessagesConsumed() {
+        logger.info("No of workflows started: {}", zeebeOperationsConfig.noOfWorkflows);
+        int count = 0;
+        for(String processInstanceKey : processInstanceKeySet){
+            if(kafkaPollProcessInstanceKeySet.contains(processInstanceKey)){
+                count++;
+            }
+        }
+        assertThat(count).isEqualTo(zeebeOperationsConfig.noOfWorkflows);
+    }
+
+    private String getFileContent(String fileUrl) {
+        try {
+            return IOUtils.toString(URI.create(fileUrl), StandardCharsets.UTF_8);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private String uploadBPMNFile(String fileContent) throws MalformedURLException {
+        RequestSpecification requestSpec = Utils.getDefaultSpec();
+        return RestAssured.given(requestSpec)
+                .baseUri(zeebeOperationsConfig.zeebeOperationContactPoint)
+                .multiPart(getMultiPart(fileContent))
+                .expect()
+                .spec(new ResponseSpecBuilder().expectStatusCode(200).build())
+                .when()
+                .post(zeebeOperationsConfig.uploadBpmnEndpoint)
+                .andReturn().asString();
+    }
+
+    private MultiPartSpecification getMultiPart(String fileContent) {
+        return new MultiPartSpecBuilder(fileContent.getBytes()).
+                fileName("zeebe-test.bpmn").
+                controlName("file").
+                mimeType("text/plain").
+                build();
+    }
+
+    private String sendWorkflowRequest(String endpoint, String requestBody){
+        RequestSpecification requestSpec = Utils.getDefaultSpec();
+        return RestAssured.given(requestSpec)
+                .baseUri(zeebeOperationsConfig.zeebeOperationContactPoint)
+                .body(requestBody)
+                .expect()
+                .spec(new ResponseSpecBuilder().expectStatusCode(200).build())
+                .when()
+                .post(endpoint)
+                .andReturn().asString();
+    }
+
+    private KafkaConsumer<String, String> createKafkaConsumer() {
+        String hostname = UUID.randomUUID().toString();
+        Map<String, Object> properties = new HashMap<>();
+        properties.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, kafkaConfig.kafkaBroker);
+        properties.put(ConsumerConfig.CLIENT_ID_CONFIG, hostname);
+        properties.put(ConsumerConfig.GROUP_ID_CONFIG, "group-1");
+        properties.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class.getName());
+        properties.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class.getName());
+        return new KafkaConsumer<>(properties);
+    }
+
+    private void processKafkaRecords(ConsumerRecords<String, String> records){
+        if(records.isEmpty()){
+            return;
+        }
+
+        for(ConsumerRecord<String, String> record: records){
+            JsonObject payload = JsonParser.parseString(record.value()).getAsJsonObject();
+            JsonObject recordValue = payload.get("value").getAsJsonObject();
+            String processInstanceKey = recordValue.get("processInstanceKey").getAsString();
+            kafkaPollProcessInstanceKeySet.add(processInstanceKey);
+        }
+    }
+
+}

--- a/src/test/java/org/mifos/integrationtest/cucumber/stepdef/ZeebeStepDef.java
+++ b/src/test/java/org/mifos/integrationtest/cucumber/stepdef/ZeebeStepDef.java
@@ -174,6 +174,8 @@ public class ZeebeStepDef extends BaseStepDef {
         properties.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class.getName());
         properties.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class.getName());
         return new KafkaConsumer<>(properties);
+
+        // adding dummy comment
     }
 
     private void processKafkaRecords(ConsumerRecords<String, String> records){

--- a/src/test/java/resources/zeebe.feature
+++ b/src/test/java/resources/zeebe.feature
@@ -1,4 +1,4 @@
-@ZeebeExport
+@gov
 Feature: Zeebe exporter test
 
   Scenario: Test zeebe-export kafka topic

--- a/src/test/java/resources/zeebe.feature
+++ b/src/test/java/resources/zeebe.feature
@@ -1,0 +1,8 @@
+@ZeebeExport
+Feature: Zeebe exporter test
+
+  Scenario: Test zeebe-export kafka topic
+    Given I have tenant as "gorilla"
+    When I upload the BPMN file to zeebe
+    And I can start test workflow n times with message "Hello World" and listen on kafka topic
+    Then The number of workflows started should be equal to number of message consumed from kafka topic


### PR DESCRIPTION
## Description

This test includes

1. Uploading the BPMN file. This BPMN file is read from a remote github repository.
2. Starting the workflow n number of times where n is configurable.
3. Creating of kafka consumer and polling the kafka topic (zeebe-export)
4. Asserting that number of workflows started and number of process instance keys consumed from kafka topic are equal.

[GOV-449](https://mifosforge.jira.com/browse/GOV-449)

## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] Design related bullet points or design document link related to this PR added in the description above.

- [ ] Updated corresponding Postman Collection or Api documentation for the changes in this PR.

- [ ] Create/update unit or integration tests for verifying the changes made.

- [ ] Add required Swagger annotation and update API documentation with details of any API changes if applicable

- [ ] Followed the naming conventions as given in https://docs.google.com/document/d/1Q4vaMSzrTxxh9TS0RILuNkSkYCxotuYk1Xe0CMIkkCU/edit?usp=sharing


[GOV-449]: https://mifosforge.jira.com/browse/GOV-449?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ